### PR TITLE
add nginx to docker dev setup to route react to django api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,16 @@ services:
       timeout: 5s
       retries: 5
 
-  
+  # Nginx Service for Development
+  nginx:
+    image: nginx:1.25
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx_dev/dev.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - frontend
+      - backend
 
 # Persistent Data Storage
 volumes:

--- a/nginx_dev/dev.conf
+++ b/nginx_dev/dev.conf
@@ -1,0 +1,41 @@
+upstream backend {
+    server backend:8000;
+}
+
+upstream frontend {
+    server frontend:3000;
+}
+
+server {
+    listen 80;
+    server_name localhost;
+
+    # Frontend
+    location / {
+        proxy_pass http://frontend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Backend API
+    location /api/ {
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Backend Static Files
+    location /static/ {
+        proxy_pass http://backend;
+    }
+
+    # Backend Media Files
+    location /media/ {
+        proxy_pass http://backend;
+    }
+}


### PR DESCRIPTION
## 🛠 Add NGINX Configuration for Routing React API Requests  

### Summary  
This update introduces a basic NGINX configuration (`nginx_dev/dev.conf`) to correctly route React's API requests to the corresponding Django container.  

### Changes  
- Added `nginx_dev/dev.conf`  
- Configured routing for React API requests  
- Ensured proper proxying to the Django backend  

### How to Test  

run: 
`docker compose -f docker-compose.yml watch`
3. Make an API request from the frontend and verify it reaches the correct Django container.  

