### PR TITLE
attempting fix for sso users. Now, every time an SSO user attempts to…

### DIFF
--- a/mishmash/api/views.py
+++ b/mishmash/api/views.py
@@ -1731,6 +1731,7 @@ class UserViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["post"], permission_classes=[IsAdminOrSelf])
     def refresh_transcript(self, request, pk=None):
         user = self.get_object()
+        user.save() # this will re-attempt to connect ulink for sso users
 
         if not user.ulink_username:
             return Response({"error": "This user does not have a Ulink username linked."},

--- a/mishmash/frontend/src/pages/Dashboard.js
+++ b/mishmash/frontend/src/pages/Dashboard.js
@@ -211,6 +211,14 @@ const Dashboard = () => {
     STUDENT_ROUTES
   );
 
+  const refreshPrerequisites = async () => {
+    try {
+      await axiosInstance.post(`/api/users/${user.id}/refresh_transcript/`);
+    } catch (err) {
+      console.error("Failed to connect user to a Ulink account.");
+    }
+  };
+
   // Handle default route
   useEffect(() => {
     // Only adjust the route if user is available
@@ -236,6 +244,8 @@ const Dashboard = () => {
 
   useEffect(() => {
     if (user?.is_sso && !user?.ulink_username) {
+      // try to connect ulink. If fails, warn user.
+      refreshPrerequisites();
       setUlinkDialogOpen(true);
     }
   }, [user]);


### PR DESCRIPTION
… log in, and their ulink username was taken before, the system attempts to claim the username again. If this fails, warn the user as before